### PR TITLE
Run docker workflow automatically

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,6 @@ on:
 
 
 env:
-  DOCKERHUB_REPOSITORY: psemiletov/logfilegen
   PLATFORMS: linux/amd64,linux/arm64
 
 
@@ -49,5 +48,5 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:latest
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ env.GITHUB_TAG }}
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:latest
+            ${{ secrets.DOCKERHUB_REPOSITORY }}:${{ env.GITHUB_TAG }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,13 @@ name: Docker
 
 on:
   push:
+    branches:    
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'TODO'
+      - 'templated/**'
     tags:
       - '*'
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY . /src
 # Build
 WORKDIR /src
 RUN make
-RUN make install
 
 
 # Ubuntu 22.04


### PR DESCRIPTION
Please find a change which will run Docker workflow in an automatic way on the push with
1. Tag
2. Main branch with excluded paths

No more manual run are required and we should react only to the errors.

Also, I moved variable `DOCKERHUB_REPOSITORY` to the Secrets. It is a public value, but in order to test workflow on my end I need to redefine it in workflow which is no so suitable.
If we will store this value in the Secrets it should be transparent for everyone with their own reposiltories.

Thank you!
