### PR TITLE
Add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] - "
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Create a template ...
+2. Run logfilegen with the parameters ....
+3. See error
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+
+**Environment:**
+ - OS: Ubuntu 22.04 / Windows 11 / macOS 13
+ - Logfilegen: 0.2.0
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/psemiletov/logfilegen/discussions
+    about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request] - "
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Docker
 
 
-
 on:
   push:
     branches:    
@@ -11,6 +10,7 @@ on:
       - 'LICENSE'
       - 'TODO'
       - 'templates/**'
+      - '.github/ISSUE_TEMPLATE/**'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ on:
       - 'LICENSE'
       - 'TODO'
       - 'templates/**'
+      - '.github/ISSUE_TEMPLATE/**'
     tags:
       - '*'
   workflow_dispatch:


### PR DESCRIPTION
Hello Peter,

I've tried to play with the Issue templates  - [Configuring issue templates for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).

It may help people to easier create a feature request or ask a question. You can adopt it in a way you will find it more suitable.

It will look like on the image
<img width="1191" alt="Screenshot 2023-01-11 at 19 40 46" src="https://user-images.githubusercontent.com/88528265/211879444-3b8afee6-2533-4aac-94e9-fdbcf9a1c85c.png">


