### PR TITLE
Add Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag
+        required: false
+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ github.event.inputs.tag != '' || github.ref_name != '' || !cancelled() }}
+    steps:
+      - name: Compute tag
+        run: if [[ -z "${{ github.event.inputs.tag }}" ]]; then echo "GITHUB_TAG=${{ github.ref_name }}" >> "${GITHUB_ENV}"; else echo "GITHUB_TAG=${{ github.event.inputs.tag }}" >> "${GITHUB_ENV}"; fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prerequisites
+        run: |
+          sudo apt update
+          sudo apt install git make g++
+
+      - name: Build
+        run: make
+
+      - name: SHA summ
+        run: sha256sum logfilegen > logfilegen.sha256.txt
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          append_body: true
+          tag_name: ${{ env.GITHUB_TAG }}
+          files: |
+            logfilegen
+            logfilegen.sha256.txt


### PR DESCRIPTION
Hello Peter,

This is a try to add Release workflow. It may be helpfully to share prebuilt binaries with the community.

It is based on the [softprops/action-gh-release](https://github.com/softprops/action-gh-release) action and basically will just attach logfilegen binary and sha256 sum file to the existing release.

It will be triggered by the git tag and it means that after you will add a release and create a tag, it will be triggered automatically and will attach the assets.

Also, there is an option to trigger it manually, and you can pass a tag value like `0.1.0` and it will update past releases wit the assets.

In the future we can consider to share prebuilt binaries for more platforms/architectures, but as a fast start linux-amd64 should be better than nothing.

And we will have another installation option
```bash
# Latest version
curl -L https://github.com/psemiletov/logfilegen/releases/latest/download/logfilegen -o logfilegen

# Specific version
curl -L https://github.com/psemiletov/logfilegen/releases/download/0.1.0/logfilegen -o logfilegen

# Install
chmod +755 logfilegen
sudo mv logfilegen /usr/bin
```

Let's see it in action :)