### PR TITLE
Fix Release workflow when triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ github.event.inputs.tag != '' || github.ref_name != '' || !cancelled() }}
+    if: ${{ github.event.inputs.tag != '' || github.ref_type == 'tag' }}
     steps:
       - name: Compute tag
         run: if [[ -z "${{ github.event.inputs.tag }}" ]]; then echo "GITHUB_TAG=${{ github.ref_name }}" >> "${GITHUB_ENV}"; else echo "GITHUB_TAG=${{ github.event.inputs.tag }}" >> "${GITHUB_ENV}"; fi
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GITHUB_TAG }}
 
       - name: Prerequisites
         run: |


### PR DESCRIPTION
Hello Peter,

I did some additional tests and observed that when Release workflow is triggered manually it will checkout the latest code and not the one specified by passed tag.

This fix will consider manually passed tag for code checkout. You can run it again for `0.2.0` release and it will replace assets with the new ones compiled from the appropriate tag.

Thank you!