### PR TITLE
Bump configure-aws-credentials version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -167,7 +167,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Hello, Peter

A new major version of the [configure-aws-credentials was just released](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v2.0.0) and let's switch to it from an [intermediate one](https://github.com/aws-actions/configure-aws-credentials/issues/632).

Thanks!