### PR TITLE
Add logfilegen_compiler option

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -111,6 +111,7 @@ env:
   TERRAFORM_VERSION: 1.3.9
   AWAITING_TIME: 300
   LOGFILEGEN_VERSION: main
+  LOGFILEGEN_COMPILER: gcc
   AZ: ""
 
 
@@ -155,13 +156,14 @@ jobs:
     steps:
       - name: Variables
         run: |
-          [[ ${{ env.TF_VAR_data_volume_size }} == "null" ]] && echo "TF_VAR_data_volume_size=0" >> $GITHUB_ENV
-          [[ ${{ env.TF_VAR_data_volume_type }} == "null" ]] && echo "TF_VAR_data_volume_type=" >> $GITHUB_ENV
-          [[ ${{ env.TF_VAR_data_volume_iops }} == "null" ]] && echo "TF_VAR_data_volume_iops=0" >> $GITHUB_ENV
-          [[ ${{ env.TF_VAR_data_volume_throughput }} == "null" ]] && echo "TF_VAR_data_volume_throughput=0" >> $GITHUB_ENV
-          echo "TF_VAR_name=${{ env.NAME }}" >> $GITHUB_ENV
-          echo "TF_VAR_az=${{ env.AZ }}" >> $GITHUB_ENV
-          echo "TF_VAR_logfilegen_version=${{ env.LOGFILEGEN_VERSION }}" >> $GITHUB_ENV
+          [[ "${{ env.TF_VAR_data_volume_size }}" == "null" ]] && echo "TF_VAR_data_volume_size=0" >> $GITHUB_ENV
+          [[ "${{ env.TF_VAR_data_volume_type }}" == "null" ]] && echo "TF_VAR_data_volume_type=" >> $GITHUB_ENV
+          [[ "${{ env.TF_VAR_data_volume_iops }}" == "null" ]] && echo "TF_VAR_data_volume_iops=0" >> $GITHUB_ENV
+          [[ "${{ env.TF_VAR_data_volume_throughput }}" == "null" ]] && echo "TF_VAR_data_volume_throughput=0" >> $GITHUB_ENV
+          [[ -n "${{ vars.NAME }}" ]] && echo "TF_VAR_name=${{ vars.NAME }}" >> $GITHUB_ENV || echo "TF_VAR_name=${{ env.NAME }}" >> $GITHUB_ENV
+          [[ -n "${{ vars.AZ }}" ]] && echo "TF_VAR_az=${{ vars.AZ }}" >> $GITHUB_ENV || echo "TF_VAR_az=${{ env.AZ }}" >> $GITHUB_ENV
+          [[ -n "${{ vars.LOGFILEGEN_VERSION }}" ]] && echo "TF_VAR_logfilegen_version=${{ vars.LOGFILEGEN_VERSION }}" >> $GITHUB_ENV || echo "TF_VAR_logfilegen_version=${{ env.LOGFILEGEN_VERSION }}" >> $GITHUB_ENV
+          [[ -n "${{ vars.LOGFILEGEN_COMPILER }}" ]] && echo "TF_VAR_logfilegen_compiler=${{ vars.LOGFILEGEN_COMPILER }}" >> $GITHUB_ENV || echo "TF_VAR_logfilegen_compiler=${{ env.LOGFILEGEN_COMPILER }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/benchmark/aws/main.tf
+++ b/benchmark/aws/main.tf
@@ -25,6 +25,7 @@ module "instance-01" {
   enable_logfilegen       = var.enable_logfilegen
   enable_benchmark        = var.enable_benchmark
   enable_docker           = var.enable_docker
+  logfilegen_compiler     = var.logfilegen_compiler
   logfilegen_version      = var.logfilegen_version
   benchmark_count         = var.benchmark_count
   benchmark_duration      = var.benchmark_duration

--- a/benchmark/aws/modules/vm/aws-ec2.tf
+++ b/benchmark/aws/modules/vm/aws-ec2.tf
@@ -83,7 +83,8 @@ data "cloudinit_config" "this" {
       filename     = "03-logfilegen.sh"
       content_type = "text/x-shellscript"
       content = templatefile("${path.module}/files/03-logfilegen.sh", {
-        logfilegen_version = var.logfilegen_version
+        logfilegen_version  = var.logfilegen_version,
+        logfilegen_compiler = var.logfilegen_compiler
       })
     }
   }

--- a/benchmark/aws/modules/vm/files/02-node.sh
+++ b/benchmark/aws/modules/vm/files/02-node.sh
@@ -22,10 +22,10 @@ fi
 # Install packages
 case "$os" in
   ubuntu) apt update
-          apt install -y git make g++ cmake pkg-config systemd-coredump unzip jq
+          apt install -y git make g++ clang cmake pkg-config systemd-coredump unzip jq
           ;;
 
-  amazon) yum -y git make gcc-c++ systemd-coredump unzip jq
+  amazon) yum install -y git make gcc-c++ clang systemd-coredump unzip jq
           ;;
 
        *) echo "Unknown OS"

--- a/benchmark/aws/modules/vm/files/03-logfilegen.sh
+++ b/benchmark/aws/modules/vm/files/03-logfilegen.sh
@@ -4,12 +4,17 @@
 base_dir="/opt"
 logfilegen_dir="logfilegen"
 logfilegen_version="${logfilegen_version}"
+logfilegen_compiler="${logfilegen_compiler}"
 
 # Get sources
 git clone -b "$logfilegen_version" https://github.com/psemiletov/logfilegen.git "$base_dir/$logfilegen_dir"
 
 # Compile
-make -C "$base_dir/$logfilegen_dir"
+if [[ "$logfilegen_compiler" == "clang" ]]; then
+  make -C "$base_dir/$logfilegen_dir" CXX=clang++
+else
+  make -C "$base_dir/$logfilegen_dir"
+fi
 
 # Install
 make -C "$base_dir/$logfilegen_dir" install

--- a/benchmark/aws/modules/vm/variables.tf
+++ b/benchmark/aws/modules/vm/variables.tf
@@ -140,6 +140,12 @@ variable "enable_docker" {
   default     = false
 }
 
+variable "logfilegen_compiler" {
+  description = "Compiler to use for logfilegen build."
+  type        = string
+  default     = "gcc"
+}
+
 variable "logfilegen_version" {
   description = "Logfilegen version to install from GitHub sources."
   type        = string

--- a/benchmark/aws/variables.auto.tfvars
+++ b/benchmark/aws/variables.auto.tfvars
@@ -15,3 +15,4 @@
 # data_volume_iops        = 3000            # only for gp3, io1, io2 | gp3 up to 16000, io1/io2 up to 64000
 # data_volume_throughput  = 125             # only for gp3, up to 1000
 # logfilegen_version      = "main"          # 2.0.0
+# logfilegen_compiler     = "gcc"           # clang

--- a/benchmark/aws/variables.tf
+++ b/benchmark/aws/variables.tf
@@ -140,6 +140,12 @@ variable "enable_docker" {
   default     = false
 }
 
+variable "logfilegen_compiler" {
+  description = "Compiler to use for logfilegen build."
+  type        = string
+  default     = "gcc"
+}
+
 variable "logfilegen_version" {
   description = "Logfilegen version to install from GitHub sources."
   type        = string


### PR DESCRIPTION
Hello, Peter

Please find some small changes which will permit to set `logfilegen_compiler` variable and use it inside `03-logfilegen.sh` script.
Default value is `gcc` and when we set it to the `clang` it will be used as a compiler.

Also, because [GitHub Actions workflow_dispatch inputs is limited to 10](https://github.com/community/community/discussions/8774), this variable can be set directly in the workflow file as for now.

There also a workaround and we may set it via GitHub `vars` context - [Using the `vars` context to access configuration variable values](https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values).

<img width="1194" alt="Screenshot 2023-03-08 at 01 48 29" src="https://user-images.githubusercontent.com/88528265/223581722-59ff7ebe-5795-4b5a-853a-a0d73fcb01e5.png">
